### PR TITLE
Fixed improper reference with exportCanvas in exportDiagram. CLI expo…

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -1102,5 +1102,5 @@ def exportDiagramImage(filename=None):
     app.withdraw()
     app.update()
     app.drawDiagram()
-    app.exportCanvas(filename=filename)
+    app.exportCanvas(fileName=filename)
     app.destroy()


### PR DESCRIPTION
…rt should work now. No idea how this error came about when for client meeting it was fine. Maybe prior commit included this typo somehow.